### PR TITLE
Fix: Vorzeichenfehler bei FX-Korrektur für die Tageskurs-Methode

### DIFF
--- a/calculate_tax_report.py
+++ b/calculate_tax_report.py
@@ -1255,9 +1255,7 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None):
             if category == 'FUT':
                 continue
 
-            cost_raw = abs(safe_float(lot.get('cost'), 0))
-            if cost_raw < 0.01:
-                continue
+            cost_raw = safe_float(lot.get('cost'), 0)
 
             fx_close = safe_float(lot.get('fxRateToBase'), 0)
             open_dt = lot.get('openDateTime', '')


### PR DESCRIPTION
**Fix: Vorzeichenfehler bei FX-Korrektur für die Tageskurs-Methode**

Bezieht sich auf das heutige Update der Tageskurs-Methode in Commit [[6c1bda7](https://github.com/KonvexInvestment/ibkr-steuer/commit/6c1bda7e34118972263df7b31064d50b50e5e517)].

Beim Testen der neuen Funktion ist mir aufgefallen, dass mit dem berechneten Währungsdelta nicht der gleiche Gewinn in EUR herausgekommen ist wie in meiner manuellen Rechnung. Durch die Korrektur, dass auch negative Werte negativ bleiben (bei Stillhaltergeschäften), stimmen die Werte nun exakt überein.


Die bisherige Logik nutzte `cost_raw = abs(safe_float(lot.get('cost'), 0))`, was bei Stillhaltergeschäften (negativer cost-Wert durch Prämienerhalt) zu einer falschen Berechnung des Währungs-Deltas führte. Durch das Entfernen der Absolutwert-Bildung werden nun auch Short-Positionen mit dem korrekten steuerlichen Vorzeichen in die Tageskurs-Methode (§ 20 Abs. 4 EStG) einbezogen.

Änderungen:
- `cost_raw` erlaubt nun negative Werte für Stillhaltergeschäfte.
- Filter `cost_raw < 0.01` entfernt, da sonst Trades mit negativen Werten in `cost` unberücksichtigt blieben.