### PR TITLE
Improve QYLD and special-product tax reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,47 @@ Automatische Berechnung der Anlage KAP und KAP-INV aus Interactive Brokers Flex 
 
 Für genauere Ergebnisse können zusätzlich Vorjahres-XMLs hochgeladen werden (Multi-Year FX-FIFO, Cross-Year Stillhalter).
 
+Die technischen XML-Felder sind grundsätzlich unabhängig von der Portalsprache. Am besten getestet ist derzeit eine englische Flex Query; einzelne von IBKR gelieferte Beschreibungstexte können sprachabhängig sein.
+
 ## Datenschutz
 
 Die App läuft **vollständig im Browser** via WebAssembly (stlite/Pyodide). Es gibt keinen Server, keine Datenbank, keine Analyse. Ihre IBKR-Daten verlassen zu keinem Zeitpunkt Ihren Rechner.
 
 ## Lokale Entwicklung
 
+### macOS / Linux
+
 ```bash
 git clone https://github.com/KonvexInvestment/ibkr-steuer.git
 cd ibkr-steuer
 python3 -m venv .venv
 source .venv/bin/activate
-pip install streamlit openpyxl
-streamlit run app.py
+python -m pip install streamlit openpyxl
+python -m streamlit run app.py
+```
+
+### Windows 10/11 (PowerShell)
+
+```powershell
+git clone https://github.com/KonvexInvestment/ibkr-steuer.git
+cd ibkr-steuer
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install streamlit openpyxl
+python -m streamlit run app.py
+```
+
+Falls PowerShell die Aktivierung blockiert, kann die App auch ohne Aktivierung gestartet werden:
+
+```powershell
+.\.venv\Scripts\python.exe -m pip install streamlit openpyxl
+.\.venv\Scripts\python.exe -m streamlit run app.py
+```
+
+Regressionstests auf allen Plattformen:
+
+```bash
+python run_tests.py
 ```
 
 ## Steuerliche Grundlagen

--- a/app.py
+++ b/app.py
@@ -534,6 +534,18 @@ def merge_report_data(reports):
                 merged_kap['etf_unknown_isins'].append(isin)
     merged['kap_inv'] = merged_kap
 
+    # no_invstg income merge (Ausschüttungen/Quellensteuer je ISIN)
+    merged_no_invstg_income = {}
+    for r in reports:
+        for isin, data in (r.get('no_invstg_income_by_isin') or {}).items():
+            if isin not in merged_no_invstg_income:
+                merged_no_invstg_income[isin] = dict(data)
+            else:
+                existing = merged_no_invstg_income[isin]
+                existing['div'] = existing.get('div', 0) + data.get('div', 0)
+                existing['wht'] = existing.get('wht', 0) + data.get('wht', 0)
+    merged['no_invstg_income_by_isin'] = merged_no_invstg_income
+
     # Anlage SO merge
     merged_so = {
         'total_gain': 0, 'total_loss': 0,
@@ -1153,6 +1165,9 @@ if de_kest_variante_b and abs(final['zeile_7']) > 0.01:
     final['zeile_38'] = 0
 
 created_at = _dt.now().strftime('%d.%m.%Y %H:%M')
+no_invstg_summary = calculate_tax_report.get_no_invstg_summary(
+    d, include_tageskurs=tageskurs_aktiv
+)
 
 # ── Basiswährung ────────────────────────────────────────────────────────────
 
@@ -1586,7 +1601,10 @@ if has_etf_data and invstg_aktiv:
                 info['wht_anrechenbar'] = new_wht_anrechenbar
                 cls_map = {0.30: 'aktienfonds', 0.15: 'mischfonds', 0.0: 'sonstiger_fonds'}
                 info['classification'] = cls_map.get(new_tfs, 'sonstiger_fonds')
-        etf_wht = abs(sum(info.get('wht_anrechenbar', info.get('wht', 0)) for info in etf_by_isin.values()))
+        etf_wht = calculate_tax_report.get_withholding_tax_for_reporting(
+            sum(info.get('wht_anrechenbar', info.get('wht', 0))
+                for info in etf_by_isin.values())
+        )
         kap_inv['etf_wht_anrechenbar_eur'] = etf_wht
 
     # ETF-Overrides in final-Dict spiegeln
@@ -1635,6 +1653,28 @@ if has_etf_data and invstg_aktiv:
             div_tax = info.get('div_taxable', 0)
             etf_table += f"| {info.get('ticker', isin)} | {cls_short} | {tfs_pct} | {fmt_de(gv_raw)} | {fmt_de(gv_tax)} | {fmt_de(div_raw)} | {fmt_de(div_tax)} |\n"
         st.markdown(etf_table)
+
+
+# ── Topf 2 · Sonderprodukte außerhalb InvStG ────────────────────────────────
+
+if no_invstg_summary:
+    section_title("Topf 2 · Sonderprodukte außerhalb InvStG")
+    st.caption(
+        "Einzelnachweis für ETPs/Trusts, die nicht als Investmentfonds nach "
+        "InvStG behandelt werden. Die Beträge sind bereits in Topf 2 enthalten. "
+        "Negative QSt-Werte kennzeichnen Erstattungen."
+    )
+    with st.expander("Sonderprodukte nach ISIN", expanded=True):
+        special_table = "| Ticker | ISIN | Realisiertes G/V | Tageskurs | Ausschüttungen | QSt | Summe Topf 2 |\n"
+        special_table += "|--------|------|----------------:|----------:|---------------:|----:|-------------:|\n"
+        for isin, info in sorted(no_invstg_summary.items(), key=lambda x: x[1].get('ticker', '')):
+            realized = info.get('gain', 0) + info.get('loss', 0)
+            special_table += (
+                f"| {info.get('ticker', isin)} | {isin} | {fmt_de(realized)} | "
+                f"{fmt_de(info.get('tageskurs', 0))} | {fmt_de(info.get('div', 0))} | "
+                f"{fmt_de(info.get('wht_reported', 0))} | {fmt_de(info.get('total', 0))} |\n"
+            )
+        st.markdown(special_table)
 
 
 # ── Anlage SO — manuelle Zuordnung (Issue #51) ───────────────────────────────
@@ -1877,6 +1917,7 @@ if d:
         f = export_context['final']
         has_etf = export_context['has_etf_data'] and export_context['invstg_aktiv']
         has_so = export_context['has_so_data']
+        special_products = export_context['no_invstg_summary']
         so_taxable = export_context['so_taxable']
         so_free = export_context['so_free']
         trade_sums = {
@@ -1938,6 +1979,14 @@ if d:
                 ("Anlage KAP-INV", "Erträge nach Teilfreistellung", f['etf_net_taxable'], ""),
                 ("Anlage KAP-INV", "Anrechenbare Quellensteuer ETF", f['etf_wht'], ""),
             ])
+        for isin, info in sorted(special_products.items(), key=lambda x: x[1].get('ticker', '')):
+            summary_rows.append((
+                "Topf 2 Sonderprodukte",
+                f"{info.get('ticker', isin)} ({isin})",
+                info.get('total', 0),
+                "no_invstg; realisiertes G/V + Tageskurs + Ausschüttungen; "
+                f"QSt {fmt_de(info.get('wht_reported', 0))} EUR; negativ = Erstattung",
+            ))
         if has_so:
             summary_rows.extend([
                 ("Anlage SO", "Steuerpflichtig <= 1 Jahr", so_taxable, ""),
@@ -2123,6 +2172,7 @@ if d:
         'created_at': created_at,
         'has_etf_data': has_etf_data,
         'invstg_aktiv': invstg_aktiv,
+        'no_invstg_summary': no_invstg_summary,
         'has_so_data': has_so_data,
         'so_taxable': so_taxable_export,
         'so_free': so_free_export,
@@ -2202,7 +2252,13 @@ if csv_cats:
         our_interest_for_comparison = d['interest_eur'] + d.get('debit_interest_eur', 0)
         rows.append(("Zinsen", csv_income['interest_eur'], our_interest_for_comparison))
     if 'withholding_tax_eur' in csv_income:
-        rows.append(("Quellensteuer", abs(csv_income['withholding_tax_eur']), our_wht))
+        rows.append((
+            "Quellensteuer",
+            calculate_tax_report.get_withholding_tax_for_reporting(
+                csv_income['withholding_tax_eur']
+            ),
+            our_wht,
+        ))
 
     # FX-Saldo-Korrektur-Diff (für Erkennung der erwarteten FX-Devisen-Abweichung)
     _fx_meta_chk = d.get('fx_option_a_meta', {}) or {}
@@ -2796,6 +2852,24 @@ if topf2_cats:
         else:
             topf2_detail_export += f"  {'Tageskurs-Korrektur':24s} G {fmt_de(0):>10} V {fmt_de(tk_corr_topf2):>10} N {fmt_de(tk_corr_topf2):>10} EUR\n"
 
+special_products_export = ""
+if no_invstg_summary:
+    special_products_export = "\nSONDERPRODUKTE AUSSERHALB INVSTG (IN TOPF 2 ENTHALTEN)\n"
+    for isin, info in sorted(no_invstg_summary.items(), key=lambda x: x[1].get('ticker', '')):
+        realized = info.get('gain', 0) + info.get('loss', 0)
+        special_products_export += (
+            f"  {info.get('ticker', isin):8s} {isin}  "
+            f"G/V {fmt_de(realized):>10}  TK {fmt_de(info.get('tageskurs', 0)):>10}  "
+            f"Aussch. {fmt_de(info.get('div', 0)):>10}  "
+            f"Summe {fmt_de(info.get('total', 0)):>10} EUR\n"
+        )
+        wht_reported = info.get('wht_reported', 0)
+        if abs(wht_reported) > 0.005:
+            wht_label = "Quellensteuer" if wht_reported > 0 else "QSt-Erstattung"
+            special_products_export += (
+                f"           {wht_label}: {fmt_de(wht_reported):>10} EUR\n"
+            )
+
 de_kest_export = ""
 if abs(zeile_7) > 0.01:
     z_kest_total = zeile_37 + zeile_38
@@ -2837,7 +2911,7 @@ TOPF 2: SONSTIGES (inkl. Termingeschäfte)
   Sonstige Verluste:    {fmt_de(final['options_loss']):>14} EUR
   ─────────────────────────────────────────────────
   Saldo Sonstiges:       {fmt_de(final['topf_2']):>14} EUR
-{topf2_detail_export}{fx_export}{sh_export}{inv_export}
+{topf2_detail_export}{special_products_export}{fx_export}{sh_export}{inv_export}
 ═══════════════════════════════════════════════════
 ANLAGE KAP EINTRAGUNGEN
 {"" if abs(final['zeile_7']) <= 0.01 else f"  Zeile 7 (inländischer Steuerabzug): {fmt_de(final['zeile_7']):>7} EUR" + chr(10) + f"  Zeile 37 (Kapitalertragsteuer): {fmt_de(final['zeile_37']):>10} EUR" + chr(10) + f"  Zeile 38 (Solidaritätszuschlag): {fmt_de(final['zeile_38']):>9} EUR" + chr(10)}

--- a/calculate_tax_report.py
+++ b/calculate_tax_report.py
@@ -25,6 +25,16 @@ def safe_float(val, default=0.0):
         return default
     return float(val)
 
+def get_withholding_tax_for_reporting(signed_cash_amount):
+    """Convert IBKR's signed tax cash flow to the report sign convention.
+
+    IBKR records tax deductions as negative cash flows and refunds as positive
+    cash flows. The tax report uses the inverse sign: creditable tax is positive,
+    while a net refund remains negative and must not become a new tax credit.
+    """
+    signed_cash_amount = safe_float(signed_cash_amount)
+    return 0.0 if signed_cash_amount == 0 else -signed_cash_amount
+
 def get_kap_inv_wht_for_reporting(kap_inv):
     """Return KAP-INV withholding tax after Teilfreistellung, with legacy fallback."""
     if not kap_inv:
@@ -40,6 +50,75 @@ def get_kap_inv_tageskurs_delta_for_reporting(report_data):
     if 'fx_correction_kap_inv_taxable' in report_data:
         return safe_float(report_data.get('fx_correction_kap_inv_taxable'))
     return safe_float((report_data.get('fx_correction_by_topf') or {}).get('KAP-INV'))
+
+def get_no_invstg_summary(report_data, include_tageskurs=False):
+    """Aggregate no-InvStG instruments by ISIN from final trade details.
+
+    Trade rows already contain Stillhalter/cross-year corrections. Optional
+    Tageskurs deltas are added separately so the summary stays reconcilable.
+    """
+    from etf_classification import get_classification, get_etf_info
+
+    report_data = report_data or {}
+    summary = {}
+    anlage_so_overrides = set(report_data.get('anlage_so_overrides_applied') or [])
+
+    def ensure_entry(isin):
+        if isin not in summary:
+            info = get_etf_info(isin) or {}
+            summary[isin] = {
+                'ticker': info.get('ticker', isin[:12]),
+                'name': info.get('name', ''),
+                'gain': 0.0,
+                'loss': 0.0,
+                'tageskurs': 0.0,
+                'div': 0.0,
+                'wht': 0.0,
+            }
+        return summary[isin]
+
+    # Auch reine Käufe ohne realisierten Gewinn sichtbar machen.
+    for isin in report_data.get('all_traded_etf_isins', []) or []:
+        if (isin and isin not in anlage_so_overrides
+                and get_classification(isin) == 'no_invstg'):
+            ensure_entry(isin)
+
+    for isin, income in (report_data.get('no_invstg_income_by_isin') or {}).items():
+        if (not isin or isin in anlage_so_overrides
+                or get_classification(isin) != 'no_invstg'):
+            continue
+        entry = ensure_entry(isin)
+        entry['div'] += safe_float(income.get('div'))
+        entry['wht'] += safe_float(income.get('wht'))
+
+    for row in report_data.get('trade_details', []) or []:
+        isin = (row.get('isin') or '').strip()
+        if (row.get('assetCategory') != 'STK' or row.get('topf') != 'Topf2'
+                or not isin or isin in anlage_so_overrides
+                or get_classification(isin) != 'no_invstg'):
+            continue
+        pnl = safe_float(row.get('pnl_eur'))
+        entry = ensure_entry(isin)
+        if pnl >= 0:
+            entry['gain'] += pnl
+        else:
+            entry['loss'] += pnl
+
+    if include_tageskurs:
+        for lot in report_data.get('fx_correction_details', []) or []:
+            isin = (lot.get('isin') or '').strip()
+            if (lot.get('topf') != 'Topf2' or not isin
+                    or isin in anlage_so_overrides
+                    or get_classification(isin) != 'no_invstg'):
+                continue
+            ensure_entry(isin)['tageskurs'] += safe_float(lot.get('delta_eur'))
+
+    for entry in summary.values():
+        entry['trade_net'] = entry['gain'] + entry['loss'] + entry['tageskurs']
+        entry['total'] = entry['trade_net'] + entry['div']
+        entry['wht_reported'] = get_withholding_tax_for_reporting(entry['wht'])
+
+    return summary
 
 GERMAN_DIVIDEND_TAX_TOTAL_RATE = 0.26375
 GERMAN_KEST_RATE = 0.25
@@ -1587,6 +1666,7 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
     # no_invstg ETP tracking (for plausibility check — IBKR counts these as STK/Aktien)
     no_invstg_gain = 0.0
     no_invstg_loss = 0.0
+    no_invstg_income_by_isin = {}
 
     # Anlage SO tracking (§23 EStG — physische Gold-ETCs mit Lieferanspruch)
     # Trades are collected for holding period analysis; gains/losses excluded from KAP entirely
@@ -2988,6 +3068,17 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
     funds_processed = 0
     funds_skipped_year = 0
 
+    def ensure_no_invstg_income(isin):
+        if isin not in no_invstg_income_by_isin:
+            info = get_etf_info(isin) or {}
+            no_invstg_income_by_isin[isin] = {
+                'ticker': info.get('ticker', isin[:12]),
+                'name': info.get('name', ''),
+                'div': 0.0,
+                'wht': 0.0,
+            }
+        return no_invstg_income_by_isin[isin]
+
     for f in funds:
         code = f.get('activityCode')
         if not code and is_german_dividend_tax_row(f):
@@ -3035,13 +3126,16 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
         # Ausschüttungen auf physische Edelmetall-ETCs sind nicht als InvStG-
         # Fondsausschüttungen zu behandeln — sie fließen in reguläre Dividenden.
         is_etf_fund = False
+        is_no_invstg = False
         fund_isin = ''
+        fund_cls = None
         _fund_isin_raw = f.get('isin', '').strip()
         if f.get('subCategory') == 'ETF' or (_fund_isin_raw and is_known_etf(_fund_isin_raw)):
             fund_isin = _fund_isin_raw
             if fund_isin:
-                cls = _effective_classification(fund_isin)
-                if cls not in ('no_invstg', 'anlage_so'):
+                fund_cls = _effective_classification(fund_isin)
+                is_no_invstg = fund_cls == 'no_invstg'
+                if fund_cls not in ('no_invstg', 'anlage_so'):
                     is_etf_fund = True
 
         if code == 'DIV':
@@ -3049,12 +3143,14 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
                 etf_dividends_eur += amount_eur
                 if fund_isin not in etf_by_isin:
                     info = get_etf_info(fund_isin)
-                    etf_by_isin[fund_isin] = {'ticker': info['ticker'] if info else fund_isin[:12], 'name': info['name'] if info else '', 'classification': cls or 'sonstiger_fonds', 'gain': 0.0, 'loss': 0.0, 'div': 0.0, 'wht': 0.0}
+                    etf_by_isin[fund_isin] = {'ticker': info['ticker'] if info else fund_isin[:12], 'name': info['name'] if info else '', 'classification': fund_cls or 'sonstiger_fonds', 'gain': 0.0, 'loss': 0.0, 'div': 0.0, 'wht': 0.0}
                 etf_by_isin[fund_isin]['div'] += amount_eur
             elif is_de_isin(f) and funds_match_key(f) in german_dividend_tax_keys:
                 domestic_taxed_dividends_eur += amount_eur
             else:
                 dividends_eur += amount_eur
+                if is_no_invstg:
+                    ensure_no_invstg_income(fund_isin)['div'] += amount_eur
         elif code == 'PIL':
             # Payment in Lieu: positive = received (long position lent out)
             # negative = paid (short position owes dividend)
@@ -3063,12 +3159,14 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
                 etf_dividends_eur += amount_eur
                 if fund_isin not in etf_by_isin:
                     info = get_etf_info(fund_isin)
-                    etf_by_isin[fund_isin] = {'ticker': info['ticker'] if info else fund_isin[:12], 'name': info['name'] if info else '', 'classification': cls or 'sonstiger_fonds', 'gain': 0.0, 'loss': 0.0, 'div': 0.0, 'wht': 0.0}
+                    etf_by_isin[fund_isin] = {'ticker': info['ticker'] if info else fund_isin[:12], 'name': info['name'] if info else '', 'classification': fund_cls or 'sonstiger_fonds', 'gain': 0.0, 'loss': 0.0, 'div': 0.0, 'wht': 0.0}
                 etf_by_isin[fund_isin]['div'] += amount_eur
             elif is_de_isin(f) and funds_match_key(f) in german_dividend_tax_keys:
                 domestic_taxed_dividends_eur += amount_eur
             else:
                 dividends_eur += amount_eur
+                if is_no_invstg:
+                    ensure_no_invstg_income(fund_isin)['div'] += amount_eur
         elif code == 'DINT':
             # Margin-Sollzinsen, Leihgebühren, SYEP — NICHT abzugsfähig (§20 Abs. 9 EStG)
             # Werbungskosten bei Kapitalerträgen → nur Sparer-Pauschbetrag erlaubt
@@ -3078,9 +3176,8 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
             # INTP = Accrued interest paid (Stückzinsen — negative Einnahme, abzugsfähig)
             interest_eur += amount_eur
         elif code in ['FRTAX', 'WHT']:
-            # Tax is usually negative. We want the absolute value of the NET tax paid.
-            # If there are adjustments/refunds (positive), they reduce the total tax.
-            # We track the sum directly and take the absolute value later.
+            # IBKR: Einbehalt negativ, Erstattung positiv. Zuerst vorzeichenbehaftet
+            # saldieren; die Berichtskonvention wird erst nach dem Loop angewendet.
             if is_german_dividend_tax_row(f) and not is_etf_fund:
                 domestic_withholding_tax_eur += amount_eur
             elif is_etf_fund:
@@ -3089,9 +3186,13 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
                     etf_by_isin[fund_isin]['wht'] += amount_eur
             else:
                 withholding_tax_eur += amount_eur
+                if is_no_invstg:
+                    ensure_no_invstg_income(fund_isin)['wht'] += amount_eur
             
-    # Finalize tax: convert net sum to absolute value for "Tax Paid" field
-    withholding_tax_eur = abs(withholding_tax_eur)
+    # Ausländische QSt: Vorzeichen invertieren, nicht absolut setzen. So bleibt
+    # ein Erstattungsüberschuss im Bericht negativ statt zur Scheingutschrift zu werden.
+    withholding_tax_eur = get_withholding_tax_for_reporting(withholding_tax_eur)
+    # Inländische KESt/Soli ist ein separater bestehender Berechnungspfad.
     domestic_withholding_tax_eur = abs(domestic_withholding_tax_eur)
     zeile_37_kapitalertragsteuer_eur = (
         domestic_withholding_tax_eur
@@ -3752,16 +3853,19 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
         etf_loss_taxable += data['loss_taxable']
         etf_div_taxable += data['div_taxable']
 
-    etf_wht_abs = abs(etf_wht_eur)  # positive for reporting
+    etf_wht_reported = get_withholding_tax_for_reporting(etf_wht_eur)
     # §56 Abs. 6 InvStG: anrechenbare QSt um Teilfreistellung kürzen
-    etf_wht_anrechenbar = abs(sum(data.get('wht_anrechenbar', data.get('wht', 0)) for data in etf_by_isin.values()))
+    etf_wht_anrechenbar = get_withholding_tax_for_reporting(
+        sum(data.get('wht_anrechenbar', data.get('wht', 0))
+            for data in etf_by_isin.values())
+    )
     etf_net_taxable = etf_gain_taxable + etf_loss_taxable + etf_div_taxable
 
     if etf_by_isin:
         tfs_reduction = (etf_invstg_gain + etf_invstg_loss + etf_dividends_eur) - etf_net_taxable
         print(f"InvStG ETFs: {len(etf_by_isin)} Fonds erkannt. "
               f"Gewinne {etf_invstg_gain:,.2f}, Verluste {etf_invstg_loss:,.2f}, "
-              f"Dividenden {etf_dividends_eur:,.2f}, WHT {etf_wht_abs:,.2f} EUR. "
+              f"Dividenden {etf_dividends_eur:,.2f}, WHT {etf_wht_reported:,.2f} EUR. "
               f"Teilfreistellung: {tfs_reduction:,.2f} EUR Reduktion.")
     if etf_unknown_isins:
         print(f"  (!) {len(etf_unknown_isins)} ETF(s) nicht in Klassifizierungstabelle — als sonstiger Fonds (0% TFS) behandelt.")
@@ -4306,6 +4410,7 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
         # Pool details
         "topf_1_aktien_netto": topf_1_aktien,
         "topf_2_sonstiges_netto": topf_2_sonstiges,
+        "no_invstg_income_by_isin": no_invstg_income_by_isin,
         # Keep old keys for backward compatibility
         "dividends_eur": dividends_eur,
         "domestic_taxed_dividends_eur": domestic_taxed_dividends_eur,
@@ -4353,7 +4458,7 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
             "etf_loss_taxable_eur": etf_loss_taxable,
             "etf_dividends_raw_eur": etf_dividends_eur,
             "etf_dividends_taxable_eur": etf_div_taxable,
-            "etf_wht_eur": etf_wht_abs,
+            "etf_wht_eur": etf_wht_reported,
             "etf_wht_anrechenbar_eur": etf_wht_anrechenbar,
             "etf_net_taxable_eur": etf_net_taxable,
             "etf_by_isin": etf_by_isin,
@@ -4469,7 +4574,7 @@ def calculate_tax(ib_tax_dir, tax_year=None, fx_csv_path=None, anlage_so_overrid
         if abs(tfs_reduction) > 0.01:
             print(f"    Teilfreistellung:      {-tfs_reduction:>12,.2f} EUR")
         print(f"    ETF-Netto (stpfl.):    {etf_net_taxable:>12,.2f} EUR")
-        print(f"    ETF-QSt (roh):         {etf_wht_abs:>12,.2f} EUR")
+        print(f"    ETF-QSt (roh):         {etf_wht_reported:>12,.2f} EUR")
         print(f"    ETF-QSt anrechenbar:   {etf_wht_anrechenbar:>12,.2f} EUR")
 
     if anlage_so_result['details'] or anlage_so_result['total_gain'] != 0 or anlage_so_result['total_loss'] != 0:

--- a/etf_classification.py
+++ b/etf_classification.py
@@ -175,6 +175,7 @@ ETF_CLASSIFICATION = {
     'US78464A8488': ('XSD',  'SPDR S&P Semiconductor ETF',                       'aktienfonds'),
     'US78467Y1070': ('XSM',  'SPDR S&P MidCap 400 ETF',                          'aktienfonds'),
     'US4642883984': ('XUS',  'iShares MSCI ACWI ex U.S. ETF',                    'aktienfonds'),
+    'US37954Y4834': ('QYLD', 'Global X NASDAQ 100 Covered Call ETF',             'aktienfonds'),  # 2025-Prospekt: Nasdaq-100-Aktienkorb mit gedeckten Calls
 
     # --- Commodity-ETFs (Futures/Derivate-basiert, keine Aktien) ---
     'US46138B1035': ('DBC',  'Invesco DB Commodity Index Tracking Fund',         'sonstiger_fonds'),  # Commodity Pool, Futures

--- a/run_tests.py
+++ b/run_tests.py
@@ -9,17 +9,28 @@ User in der UI sieht.
 Usage:
     python run_tests.py              # alle verfügbaren Szenarien
 """
-import json, os, shlex, sys, tempfile
+import json, os, shlex, subprocess, sys, tempfile
 
 SCENARIOS = {
     "audit1_haupt": {
-        "extract": "python extract_ibkr_data.py test_data/audit1_2024.xml {out} --history test_data/audit1_2023_history.xml",
+        "source": "test_data/audit1_2024.xml",
+        "extract": [
+            "extract_ibkr_data.py", "test_data/audit1_2024.xml", "{out}",
+            "--history", "test_data/audit1_2023_history.xml",
+        ],
     },
     "audit1_zusatz": {
-        "extract": "python extract_ibkr_data.py test_data/audit1_2024_zusatzkonto.xml {out}",
+        "source": "test_data/audit1_2024_zusatzkonto.xml",
+        "extract": [
+            "extract_ibkr_data.py", "test_data/audit1_2024_zusatzkonto.xml", "{out}",
+        ],
     },
     "audit2": {
-        "extract": "python extract_ibkr_data.py test_data/audit2_2022.xml {out} --history test_data/audit2_2021.xml",
+        "source": "test_data/audit2_2022.xml",
+        "extract": [
+            "extract_ibkr_data.py", "test_data/audit2_2022.xml", "{out}",
+            "--history", "test_data/audit2_2021.xml",
+        ],
     },
 }
 
@@ -31,6 +42,7 @@ SYNTHETIC_TESTS = [
     ("Quarterly-History-Extraction", "tests/test_quarterly_history_extraction.py"),
     ("KAP-INV-WHT", "tests/test_kap_inv_wht.py"),
     ("KAP-INV-Tageskurs-TFS", "tests/test_kap_inv_tageskurs.py"),
+    ("QYLD-und-Sonderprodukte", "tests/test_qyld_and_special_products.py"),
     ("German-Dividend-Tax", "-m unittest tests/test_german_dividend_tax.py"),
     ("FX-Margin-Negative-Balance", "tests/test_fx_negative_balance.py"),
 ]
@@ -124,24 +136,31 @@ def run_tests():
             continue
 
         # Check if source files exist
-        extract_cmd = scenario['extract'].format(out='/tmp/_test_check')
-        src_file = extract_cmd.split()[2]  # first XML path
+        src_file = scenario['source']
         if not os.path.exists(src_file):
             print(f"  SKIP  {name:20s} ({exp['description']}) — Datei nicht vorhanden")
             skipped += 1
             continue
 
         # Extract
-        out_dir = tempfile.mkdtemp(prefix=f'test_{name}_')
-        cmd = scenario['extract'].format(out=out_dir)
-        if cmd.startswith("python "):
-            cmd = f"{shlex.quote(sys.executable)} {cmd[len('python '):]}"
-        os.system(f"{cmd} > /dev/null 2>&1")
+        with tempfile.TemporaryDirectory(prefix=f'test_{name}_') as out_dir:
+            cmd = [
+                sys.executable,
+                *(arg.format(out=out_dir) for arg in scenario['extract']),
+            ]
+            completed = subprocess.run(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if completed.returncode != 0:
+                print(f"  FAIL  {name:20s} ({exp['description']}) — Extraktion fehlgeschlagen")
+                failed += 1
+                continue
 
-        # Calculate (suppress stdout)
-        import io, contextlib
-        with contextlib.redirect_stdout(io.StringIO()):
-            rd = calculate_tax(out_dir)
+            # Calculate (suppress stdout)
+            import io, contextlib
+            with contextlib.redirect_stdout(io.StringIO()):
+                rd = calculate_tax(out_dir)
 
         # GUI-defaults anwenden (Tageskurs+InvStG+Zufluss aktiv)
         user = compute_user_facing(rd)
@@ -199,8 +218,10 @@ def run_tests():
     for label, test_cmd in SYNTHETIC_TESTS:
         print(f"  RUN   {label}")
         sys.stdout.flush()
-        rc = os.system(f"{shlex.quote(sys.executable)} {test_cmd}")
-        if rc != 0:
+        completed = subprocess.run(
+            [sys.executable, *shlex.split(test_cmd)], check=False,
+        )
+        if completed.returncode != 0:
             print(f"  FAIL  {label}")
             sys.exit(1)
 

--- a/tests/test_kap_inv_wht.py
+++ b/tests/test_kap_inv_wht.py
@@ -2,13 +2,18 @@
 import contextlib
 import csv
 import io
+import math
 import os
 import sys
 import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from calculate_tax_report import calculate_tax, get_kap_inv_wht_for_reporting
+from calculate_tax_report import (
+    calculate_tax,
+    get_kap_inv_wht_for_reporting,
+    get_withholding_tax_for_reporting,
+)
 
 
 def calculate_for_funds(funds):
@@ -59,7 +64,69 @@ def test_kap_inv_wht_reporting_falls_back_for_legacy_data():
     assert get_kap_inv_wht_for_reporting({"etf_wht_eur": 150.0}) == 150.0
 
 
+def test_withholding_tax_reporting_normalizes_zero():
+    reported = get_withholding_tax_for_reporting(0)
+    assert reported == 0.0
+    assert math.copysign(1, reported) == 1.0
+
+
+def test_kap_inv_wht_refunds_keep_their_sign_after_tfs():
+    common = {
+        "currency": "EUR",
+        "subCategory": "ETF",
+        "isin": "US78462F1030",
+        "symbol": "SPY",
+    }
+    mixed = calculate_for_funds([
+        {
+            **common,
+            "activityCode": "DIV",
+            "reportDate": "2025-03-15",
+            "date": "2025-03-15",
+            "amount": "1000",
+        },
+        {
+            **common,
+            "activityCode": "WHT",
+            "reportDate": "2025-03-15",
+            "date": "2025-03-15",
+            "amount": "-150",
+        },
+        {
+            **common,
+            "activityCode": "WHT",
+            "reportDate": "2025-04-01",
+            "date": "2025-04-01",
+            "amount": "50",
+        },
+    ])["kap_inv"]
+    assert round(mixed["etf_wht_eur"], 2) == 100.00
+    assert round(mixed["etf_wht_anrechenbar_eur"], 2) == 70.00
+
+    refund_only = calculate_for_funds([
+        {
+            **common,
+            "activityCode": "DIV",
+            "reportDate": "2025-03-15",
+            "date": "2025-03-15",
+            "amount": "1000",
+        },
+        {
+            **common,
+            "activityCode": "WHT",
+            "reportDate": "2025-04-01",
+            "date": "2025-04-01",
+            "amount": "20",
+        },
+    ])["kap_inv"]
+    assert round(refund_only["etf_wht_eur"], 2) == -20.00
+    assert round(refund_only["etf_wht_anrechenbar_eur"], 2) == -14.00
+    assert round(get_kap_inv_wht_for_reporting(refund_only), 2) == -14.00
+
+
 if __name__ == "__main__":
     test_kap_inv_wht_anrechenbar_after_teilfreistellung()
     test_kap_inv_wht_reporting_falls_back_for_legacy_data()
+    test_withholding_tax_reporting_normalizes_zero()
+    test_kap_inv_wht_refunds_keep_their_sign_after_tfs()
     print("OK: KAP-INV WHT reporting")

--- a/tests/test_qyld_and_special_products.py
+++ b/tests/test_qyld_and_special_products.py
@@ -1,0 +1,264 @@
+"""Regression tests for QYLD and no-InvStG per-ISIN reporting."""
+import contextlib
+import csv
+import io
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from calculate_tax_report import calculate_tax, get_no_invstg_summary
+from etf_classification import (
+    get_etf_info,
+    get_teilfreistellung,
+    is_investment_fund,
+)
+
+
+QYLD_ISIN = "US37954Y4834"
+GLD_ISIN = "US78463V1070"
+
+
+def calculate_fixture(trades=None, funds=None):
+    trades = trades or []
+    funds = funds or []
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(os.path.join(tmp, "account_info.csv"), "w", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["currency", "tax_year", "fx_transactions_count"]
+            )
+            writer.writeheader()
+            writer.writerow({
+                "currency": "EUR",
+                "tax_year": "2025",
+                "fx_transactions_count": "0",
+            })
+        if trades:
+            with open(os.path.join(tmp, "trades.csv"), "w", newline="") as f:
+                writer = csv.DictWriter(
+                    f, fieldnames=sorted({key for row in trades for key in row})
+                )
+                writer.writeheader()
+                writer.writerows(trades)
+        if funds:
+            with open(os.path.join(tmp, "statement_of_funds.csv"), "w", newline="") as f:
+                writer = csv.DictWriter(
+                    f, fieldnames=sorted({key for row in funds for key in row})
+                )
+                writer.writeheader()
+                writer.writerows(funds)
+        with contextlib.redirect_stdout(io.StringIO()):
+            return calculate_tax(tmp)
+
+
+def test_qyld_is_aktienfonds_with_30_percent_tfs():
+    info = get_etf_info(QYLD_ISIN)
+    assert info is not None
+    assert info["ticker"] == "QYLD"
+    assert info["classification"] == "aktienfonds"
+    assert get_teilfreistellung(QYLD_ISIN) == 0.30
+    assert is_investment_fund(QYLD_ISIN)
+
+
+def test_qyld_sale_and_distribution_route_to_kap_inv():
+    rd = calculate_fixture(
+        trades=[{
+            "tradeID": "QYLD_SELL",
+            "assetCategory": "STK",
+            "subCategory": "ETF",
+            "transactionType": "ExchTrade",
+            "buySell": "SELL",
+            "symbol": "QYLD",
+            "isin": QYLD_ISIN,
+            "quantity": "-100",
+            "fifoPnlRealized": "100",
+            "fxRateToBase": "1",
+            "currency": "EUR",
+            "dateTime": "2025-12-15 10:00:00",
+            "tradeDate": "2025-12-15",
+            "reportDate": "2025-12-15",
+        }],
+        funds=[
+            {
+                "activityCode": "DIV",
+                "reportDate": "2025-12-01",
+                "date": "2025-12-01",
+                "amount": "50",
+                "currency": "EUR",
+                "subCategory": "ETF",
+                "isin": QYLD_ISIN,
+                "symbol": "QYLD",
+            },
+            {
+                "activityCode": "WHT",
+                "reportDate": "2025-12-01",
+                "date": "2025-12-01",
+                "amount": "-7.5",
+                "currency": "EUR",
+                "subCategory": "ETF",
+                "isin": QYLD_ISIN,
+                "symbol": "QYLD",
+            },
+        ],
+    )
+
+    kap_inv = rd["kap_inv"]
+    qyld = kap_inv["etf_by_isin"][QYLD_ISIN]
+    assert rd["zeile_19_netto_eur"] == 0
+    assert round(kap_inv["etf_gain_raw_eur"], 2) == 100.00
+    assert round(kap_inv["etf_dividends_raw_eur"], 2) == 50.00
+    assert round(qyld["gain_taxable"], 2) == 70.00
+    assert round(qyld["div_taxable"], 2) == 35.00
+    assert round(qyld["wht_anrechenbar"], 2) == -5.25
+    assert round(kap_inv["etf_net_taxable_eur"], 2) == 105.00
+
+
+def test_no_invstg_summary_is_reconciled_by_isin():
+    summary = get_no_invstg_summary({
+        "all_traded_etf_isins": [GLD_ISIN],
+        "trade_details": [
+            {
+                "assetCategory": "STK", "topf": "Topf2",
+                "isin": GLD_ISIN, "pnl_eur": 100,
+            },
+            {
+                "assetCategory": "STK", "topf": "Topf2",
+                "isin": GLD_ISIN, "pnl_eur": -30,
+            },
+        ],
+        "fx_correction_details": [
+            {"topf": "Topf2", "isin": GLD_ISIN, "delta_eur": 5},
+        ],
+        "no_invstg_income_by_isin": {
+            GLD_ISIN: {"div": 2, "wht": -0.3},
+        },
+    }, include_tageskurs=True)
+
+    gld = summary[GLD_ISIN]
+    assert gld["ticker"] == "GLD"
+    assert gld["gain"] == 100
+    assert gld["loss"] == -30
+    assert gld["tageskurs"] == 5
+    assert gld["div"] == 2
+    assert gld["wht_reported"] == 0.3
+    assert gld["trade_net"] == 75
+    assert gld["total"] == 77
+
+
+def test_no_invstg_sale_and_distribution_route_to_topf2_summary():
+    rd = calculate_fixture(
+        trades=[{
+            "tradeID": "GLD_SELL",
+            "assetCategory": "STK",
+            "subCategory": "ETF",
+            "transactionType": "ExchTrade",
+            "buySell": "SELL",
+            "symbol": "GLD",
+            "isin": GLD_ISIN,
+            "quantity": "-10",
+            "fifoPnlRealized": "100",
+            "fxRateToBase": "1",
+            "currency": "EUR",
+            "dateTime": "2025-12-15 10:00:00",
+            "tradeDate": "2025-12-15",
+            "reportDate": "2025-12-15",
+        }],
+        funds=[
+            {
+                "activityCode": "DIV",
+                "reportDate": "2025-12-01",
+                "date": "2025-12-01",
+                "amount": "20",
+                "currency": "EUR",
+                "subCategory": "ETF",
+                "isin": GLD_ISIN,
+                "symbol": "GLD",
+            },
+            {
+                "activityCode": "WHT",
+                "reportDate": "2025-12-01",
+                "date": "2025-12-01",
+                "amount": "-3",
+                "currency": "EUR",
+                "subCategory": "ETF",
+                "isin": GLD_ISIN,
+                "symbol": "GLD",
+            },
+        ],
+    )
+
+    summary = get_no_invstg_summary(rd)
+    gld = summary[GLD_ISIN]
+    assert round(rd["zeile_19_netto_eur"], 2) == 120.00
+    assert GLD_ISIN not in rd["kap_inv"]["etf_by_isin"]
+    assert round(gld["gain"], 2) == 100.00
+    assert round(gld["div"], 2) == 20.00
+    assert round(gld["wht_reported"], 2) == 3.00
+    assert round(gld["total"], 2) == 120.00
+
+
+def test_no_invstg_withholding_tax_refunds_keep_their_sign():
+    rd = calculate_fixture(funds=[
+        {
+            "activityCode": "WHT",
+            "reportDate": "2025-12-01",
+            "date": "2025-12-01",
+            "amount": "-10",
+            "currency": "EUR",
+            "subCategory": "ETF",
+            "isin": GLD_ISIN,
+            "symbol": "GLD",
+        },
+        {
+            "activityCode": "WHT",
+            "reportDate": "2025-12-02",
+            "date": "2025-12-02",
+            "amount": "4",
+            "currency": "EUR",
+            "subCategory": "ETF",
+            "isin": GLD_ISIN,
+            "symbol": "GLD",
+        },
+    ])
+
+    summary = get_no_invstg_summary(rd)
+    assert round(rd["zeile_41_withholding_tax_eur"], 2) == 6.00
+    assert round(summary[GLD_ISIN]["wht_reported"], 2) == 6.00
+
+    refund_only = calculate_fixture(funds=[{
+        "activityCode": "WHT",
+        "reportDate": "2025-12-03",
+        "date": "2025-12-03",
+        "amount": "5",
+        "currency": "EUR",
+        "subCategory": "ETF",
+        "isin": GLD_ISIN,
+        "symbol": "GLD",
+    }])
+    refund_summary = get_no_invstg_summary(refund_only)
+    assert round(refund_only["zeile_41_withholding_tax_eur"], 2) == -5.00
+    assert round(refund_summary[GLD_ISIN]["wht_reported"], 2) == -5.00
+
+
+def test_no_invstg_summary_excludes_anlage_so_overrides():
+    summary = get_no_invstg_summary({
+        "all_traded_etf_isins": [GLD_ISIN],
+        "anlage_so_overrides_applied": [GLD_ISIN],
+        "trade_details": [{
+            "assetCategory": "STK", "topf": "Anlage SO",
+            "isin": GLD_ISIN, "pnl_eur": 100,
+        }],
+    })
+
+    assert summary == {}
+
+
+if __name__ == "__main__":
+    test_qyld_is_aktienfonds_with_30_percent_tfs()
+    test_qyld_sale_and_distribution_route_to_kap_inv()
+    test_no_invstg_summary_is_reconciled_by_isin()
+    test_no_invstg_sale_and_distribution_route_to_topf2_summary()
+    test_no_invstg_withholding_tax_refunds_keep_their_sign()
+    test_no_invstg_summary_excludes_anlage_so_overrides()
+    print("OK: QYLD classification and no-InvStG reporting")


### PR DESCRIPTION
## Was geändert wurde

- QYLD wird anhand seiner Fondsstruktur als Aktienfonds mit 30 % Teilfreistellung behandelt und über KAP-INV geführt.
- `no_invstg`-Produkte wie GLD werden je ISIN separat in UI, Excel-Export und Textbericht ausgewiesen, ohne die bestehenden Topf-2-Summen doppelt zu erfassen.
- Die Vorzeichenlogik für ausländische Quellensteuer wurde zentralisiert: IBKR-Abzüge werden positiv berichtet, Erstattungsüberschüsse bleiben negativ und werden nicht durch `abs()` in eine Scheingutschrift verwandelt.
- Die lokale Installation unter Windows 10/11 ist im README dokumentiert.
- Der Test-Runner verwendet strukturierte `subprocess`-Aufrufe und führt die neuen Regressionstests mit aus.

## Warum

QYLD war bislang nicht explizit klassifiziert. Außerdem konnte die bisherige pauschale Betragsbildung bei einem Netto-Erstattungsüberschuss aus Quellensteuerbuchungen das Vorzeichen verlieren. Für Sonderprodukte außerhalb des InvStG fehlte ein nachvollziehbarer Einzelnachweis in den Nutzeroberflächen und Exporten.

## Wirkung

Die bestehenden KAP- und KAP-INV-Auditwerte bleiben unverändert. Neu abgesichert sind insbesondere gemischte Quellensteuerabzüge und -erstattungen sowie reine Erstattungsüberschüsse. Anlage-SO-Overrides bleiben aus der Sonderproduktdarstellung ausgeschlossen.

## Validierung

- `python3 run_tests.py`
  - reale private Auditdaten: 3 OK, 0 FAIL, 0 SKIP
  - 35 Cross-Year-Regressionstests grün
  - 31 FX-Margin-Regressionstests grün
  - KAP-INV-, QYLD-/Sonderprodukt- und Dividendsteuer-Tests grün
- `python3 -m unittest discover -s tests`
- `python3 -m compileall -q ...`
- `git diff --check`
